### PR TITLE
Add missing “s” to “tags”

### DIFF
--- a/src/_content/articles/2018-12-11-turn_jekyll_up_to_eleventy.md
+++ b/src/_content/articles/2018-12-11-turn_jekyll_up_to_eleventy.md
@@ -293,7 +293,7 @@ There are two ways you can set up collections in 11ty. The first, and most strai
 title: "Strikethrough"
 syntax-id: "strikethrough"
 syntax-summary: "~~The world is flat.~~"
-tag: extended-syntax
+tags: extended-syntax
 ---
 ```
 


### PR DESCRIPTION
Couldn't find the post source on 24Ways GitHub, but it's here too 👍. 